### PR TITLE
mod for Windows compatibility, removal of unnecessary newlines and addition of model-name prefix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# VS Code workspace files
+*.code-workspace
+
 # C extensions
 *.so
 
@@ -50,6 +53,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+tests/test_data/out/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Options:
   -m, --model-path PATH       The path to models
   -t, --transforms-path PATH  Path to a .yml file containing transformations
   -o, --output-path PATH      Path to write transformed models to
-  --drop-metadata BOOLEAN     The drop metadata flag
-  --case-sensitive BOOLEAN    The case sensitive flag
+  --drop-metadata BOOLEAN     (default=True) optionally drop source columns prefixed with "_" if that designates metadata columns not needed in target
+  --case-sensitive BOOLEAN    (default=False) treat column names as case-sensitive - otherwise force all to lower
   --help                      Show this message and exit.
 ```
 
@@ -96,6 +96,7 @@ Here are some of the limitations of the current release. If you want to contribu
 
 * Transforms only works with model generated with the code-gen package. 
 * You cannot transform a model that has already been transformed
+*     - transformation logic assumes base model contains just a list of column names with no aliases or SQL logic added
 * You cannot use wild card in fields selection for transforms (e.g. `*_id`)
-* No tests yet
+* Limited test coverage
 * No error handling yet

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use this package, you need dbt installed with a profile configured. You will 
 
 ```
 packages:
-  - package: fishtown-analytics/codegen
+  - package: dbt-labs/codegen
     version: 0.4.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Usage: dbt-generator generate [OPTIONS]
 Options:
   -s, --source-yml PATH   Source .yml file to be used
   -o, --output-path PATH  Path to write generated models
+  -m, --model STRING      Model name
+  --model-prefix BOOLEAN  optional prefix of source_name + "_" to the resulting modelname.sql to avoid model name collisions across sources 
   --source-index INTEGER  Index of the source to generate base models for
   --help                  Show this message and exit.
 ```

--- a/dbt_generator/dbt_generator.py
+++ b/dbt_generator/dbt_generator.py
@@ -22,7 +22,7 @@ def generate(source_yml, output_path, source_index, model):
     for table in tables:
         file_name = table + '.sql'
         query = generate_base_model(table, source_name)
-        file = open(os.path.join(output_path, file_name), 'w')
+        file = open(os.path.join(output_path, file_name), 'w', newline='')
         file.write(query)
 
 @dbt_generator.command(help='Transform base models in a directory using a transforms.yml file')

--- a/dbt_generator/dbt_generator.py
+++ b/dbt_generator/dbt_generator.py
@@ -14,13 +14,16 @@ def dbt_generator():
 @click.option('-s', '--source-yml', type=click.Path(), help='Source .yml file to be used')
 @click.option('-o', '--output-path', type=click.Path(), help='Path to write generated models')
 @click.option('-m','--model', type=str, default='', help='Select one model to generate')
+@click.option('--model-prefix', type=bool, default=False, help='Prefix model name with source_name + _')
 @click.option('--source-index', type=int, default=0, help='Index of the source to generate base models for')
-def generate(source_yml, output_path, source_index, model):
+def generate(source_yml, output_path, source_index, model, model_prefix):
     tables, source_name = get_base_tables_and_source(source_yml, source_index)
     if model:
         tables = [model]
     for table in tables:
         file_name = table + '.sql'
+        if model_prefix:
+            file_name = source_name + '_' + file_name
         query = generate_base_model(table, source_name)
         file = open(os.path.join(output_path, file_name), 'w', newline='')
         file.write(query)

--- a/dbt_generator/generate_base_models.py
+++ b/dbt_generator/generate_base_models.py
@@ -1,5 +1,6 @@
 import yaml
 import subprocess
+from platform import system
 
 
 def get_base_tables_and_source(file_path, source_index):
@@ -15,7 +16,10 @@ def generate_base_model(table_name, source_name):
 	bash_command = f'''
 		dbt run-operation generate_base_model --args \'{{"source_name": "{source_name}", "table_name": "{table_name}"}}\'
 	'''
-	output = subprocess.check_output(bash_command, shell=True).decode("utf-8") 
+	if system() == 'Windows':
+	    output = subprocess.check_output(["powershell.exe",bash_command]).decode("utf-8")
+	else:
+		output = subprocess.check_output(bash_command, shell=True).decode("utf-8")
 	sql_index = output.lower().find('with source as')
 	sql_query = output[sql_index:]
 	return sql_query

--- a/tests/test_data/expected/transformed__drop_metadata.sql
+++ b/tests/test_data/expected/transformed__drop_metadata.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/expected/transformed__keep_metadata.sql
+++ b/tests/test_data/expected/transformed__keep_metadata.sql
@@ -1,0 +1,27 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount,
+        _sdc_batched_at,
+        _sdc_customer_id,
+        _sdc_extracted_at,
+        _sdc_received_at,
+        _sdc_sequence as _sdc_seq,
+        _sdc_table_version
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/out/transformed__drop_metadata.sql
+++ b/tests/test_data/out/transformed__drop_metadata.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/test_sql_file.sql
+++ b/tests/test_data/test_sql_file.sql
@@ -25,4 +25,3 @@ renamed as (
 )
 
 select * from renamed
-

--- a/tests/test_data/test_transform.yml
+++ b/tests/test_data/test_transform.yml
@@ -9,3 +9,14 @@ DATE_START:
   name: START_AT
 DATE_STOP:
   name: STOP_AT
+NAME:
+  name: col_name
+  sql: CAST(NAME as varchar)
+customerid:
+  name: customer_id
+  sql: CAST(customerid as varchar)
+datetimezone:
+  name: date_time_zone
+  sql: date_trunc('day',datetimezone)
+_sdc_sequence:
+  name: _sdc_seq

--- a/tests/test_process_base_models.py
+++ b/tests/test_process_base_models.py
@@ -1,13 +1,16 @@
 import os
-from dbt_generator.process_base_models import ProcessBaseQuery
 
+import dbt_generator.process_base_models as dbt_gen
+import filecmp
 
-COLUMNS = ['canmanageclients', 'currencycode', 'customerid', 'datetimezone', 'name', 'testaccount', '_sdc_batched_at',
-           '_sdc_customer_id', '_sdc_extracted_at', '_sdc_received_at', '_sdc_sequence', '_sdc_table_version']
+COLUMNS = ['canmanageclients', 'currencycode', 'customerid', 'datetimezone', 'name', 'testaccount', 
+          '_sdc_batched_at','_sdc_customer_id', '_sdc_extracted_at', '_sdc_received_at', 
+          '_sdc_sequence', '_sdc_table_version'
+          ]
 
 
 def test_ProcessBaseQuery():
-    pbq = ProcessBaseQuery(
+    pbq = dbt_gen.ProcessBaseQuery(
         sql_file=os.path.join(os.path.dirname(__file__),
                               'test_data', 'test_sql_file.sql'),
         transforms_file=os.path.join(os.path.dirname(
@@ -15,3 +18,37 @@ def test_ProcessBaseQuery():
     )
 
     assert pbq.columns == COLUMNS
+
+
+def test_transform__drop_metadata():
+    input_file = os.path.join(os.path.dirname(__file__),'test_data', 'test_sql_file.sql')
+    trfm_file = os.path.join(os.path.dirname(__file__), 'test_data', 'test_transform.yml')
+    output_file = os.path.join(os.path.dirname(__file__),'test_data/out', 'transformed__drop_metadata.sql')
+    expected_file = os.path.join(os.path.dirname(__file__),'test_data/expected', 'transformed__drop_metadata.sql')
+
+    pbq = dbt_gen.ProcessBaseQuery(
+        sql_file= input_file,
+        transforms_file= trfm_file,
+        drop_metadata=True
+    )
+
+    pbq.write_file(output_file)
+
+    assert filecmp.cmp(expected_file, output_file, shallow=False)
+
+
+def test_transform__keep_metadata():
+    input_file = os.path.join(os.path.dirname(__file__),'test_data', 'test_sql_file.sql')
+    trfm_file = os.path.join(os.path.dirname(__file__), 'test_data', 'test_transform.yml')
+    output_file = os.path.join(os.path.dirname(__file__),'test_data/out', 'transformed__keep_metadata.sql')
+    expected_file = os.path.join(os.path.dirname(__file__),'test_data/expected', 'transformed__keep_metadata.sql')
+
+    pbq = dbt_gen.ProcessBaseQuery(
+        sql_file= input_file,
+        transforms_file= trfm_file,
+        drop_metadata=False
+    )
+
+    pbq.write_file(output_file)
+
+    assert filecmp.cmp(expected_file, output_file, shallow=False)


### PR DESCRIPTION
Proposed changes included:
1. changed subprocess call to explicitly call powershell on Windows machines (CMD failing to parse correctly)
2. removed unnecessary newlines being added during write file
3. added optional param for table-name prefixing with source-name to avoid name collisions in staging layer