### PR TITLE
Add Option for Custom String Prefix

### DIFF
--- a/dbt_generator/dbt_generator.py
+++ b/dbt_generator/dbt_generator.py
@@ -13,8 +13,6 @@ def dbt_generator():
     pass
 
 
-
-
 @dbt_generator.command(help='Gennerate base models based on a .yml source')
 @click.option('-s', '--source-yml', type=click.Path(), help='Source .yml file to be used')
 @click.option('-o', '--output-path', type=click.Path(), help='Path to write generated models')

--- a/dbt_generator/dbt_generator.py
+++ b/dbt_generator/dbt_generator.py
@@ -13,18 +13,21 @@ def dbt_generator():
     pass
 
 
+
+
 @dbt_generator.command(help='Gennerate base models based on a .yml source')
 @click.option('-s', '--source-yml', type=click.Path(), help='Source .yml file to be used')
 @click.option('-o', '--output-path', type=click.Path(), help='Path to write generated models')
 @click.option('-m', '--model', type=str, default='', help='Select one model to generate')
+@click.option('-c', '--custom_prefix', type=str, default='', help='Enter a Custom String Prefix for Model Filename')
 @click.option('--model-prefix', type=bool, default=False, help='Prefix model name with source_name + _')
 @click.option('--source-index', type=int, default=0, help='Index of the source to generate base models for')
-def generate(source_yml, output_path, source_index, model, model_prefix):
+def generate(source_yml, output_path, source_index, model, custom_prefix, model_prefix):
     tables, source_name = get_base_tables_and_source(source_yml, source_index)
     if model:
         tables = [model]
     for table in tables:
-        file_name = table + '.sql'
+        file_name = custom_prefix + table + '.sql'
         if model_prefix:
             file_name = source_name + '_' + file_name
         query = generate_base_model(table, source_name)


### PR DESCRIPTION
This proposed change includes the addition of a new option when generating base models from a source file.
The new option, "-c"/"--custom_prefix", allows the user to enter a string value to be inserted ahead of the table name when creating the base model.

This has proved useful when a specific naming convention is being followed, and prevents the need for a subsequent renaming script to be utilized. 

For example, on one instance I am working on all staging files are prepended with "stg_". Using -c would allow for this in one command.

Usage:
`dbt-generator generate -s ./models/staging/source_test/_src_source_test.yml -o ./models/staging/source_test/ -c stg_`

Output:
foo@ubu-wsl1:/home/foo/Projects/dbt-test/models/staging/source_test$ ls -l
-rwxrwxrwx 1 foo foo 297 Jan 11 15:01 stg_centers.sql
-rwxrwxrwx 1 foo foo 314 Jan 11 15:02 stg_orders.sql
-rwxrwxrwx 1 foo foo 426 Jan 11 15:03 stg_products.sql
-rwxrwxrwx 1 foo foo 280 Jan 11 15:03 stg_users.sql