### PR TITLE
fix: changing requirements.txt to reflect dbt1.0 install changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-dbt
+dbt-snowflake
+dbt-bigquery
 pyyaml
 click
 pytest


### PR DESCRIPTION
This PR is a fix for issue #4.  

Issue: 
"dbt" in requirements.txt is not compatible with dbt 1.0 and causes install failure.

Resolution:
Updated requirements.txt to include dbt-snowflake and dbt-bigquery.  
This change enable successful install with both dbt 1.0 snowflake and bigquery installs, as well as dbt 0.21 installs.  Also confirmed can run successful generate from both dbt versions.